### PR TITLE
#bugfix4-1,4-2,4-3

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -84,7 +84,9 @@
 
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
-        <li>従業員リスト</li>
+        <li>
+          <a a href="list.html" th:href="@{/employee/showList}">従業員リスト</a>
+        </li>
         <li class="active">従業員詳細</li>
       </ol>
 
@@ -132,7 +134,10 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.hireDate}">2012/11/29</span>
+                      <span
+                        th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}"
+                        >2012/11/29</span
+                      >
                     </td>
                   </tr>
                   <tr>
@@ -168,7 +173,10 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span
+                        th:utext="${#numbers.formatInteger(employee.salary, 3, 'COMMA') + '円'}"
+                        >400000円</span
+                      >
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
(4-1) 入社日の表記を「2015年05月01日」というフォーマットに変更
(4-2) 給料の表記を「233,800円」というように適切な場所にカンマを挿入
(4-3) 従業員一覧に戻るパンくずリストのリンクが切れていたので修正し、aタグを追加